### PR TITLE
Synchronizes CSV and JSON, renames `type` to `datatype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ You can run the original harvest.py tool with a cmd line like this:
 
 The output will actually be a CSV with the following schema:
 ```
-entity, type, direction, source, notes, date
+entity, datatype, direction, source, notes, date
 ```
 - The `entity` field consists of a FQDN or IPv4 address (supported entities at the moment)
-- The `type` field consists of either `FQDN` or `IPv4`, classifying the type of the entity
+- The `datatype` field consists of either `FQDN` or `IPv4`, classifying the type of the entity
 - The `direction` field will be either `inbound` or `outbound`
 - The `notes` field should cover any extra tag info we may want to persist with the data
 - The `date` field will be in `YYYY-MM-DD` format.

--- a/harvest-schema.json
+++ b/harvest-schema.json
@@ -30,7 +30,12 @@
               "id": "http://jsonschema.net/indicators/0/type",
               "required":true
             },
-            "value": {
+            "notes": {
+              "type":"string",
+              "id": "http://jsonschema.net/indicators/0/type",
+              "required":false
+            },
+            "entity": {
               "type":"string",
               "id": "http://jsonschema.net/indicators/0/value",
               "required":true


### PR DESCRIPTION
Take a look, particularly at the change to README.md. Naming a field `type` in a JSON schema is problematic and it will make our code easier to read later anyway.
