### PR TITLE
Fix tiq-test argument parsing

### DIFF
--- a/combine.py
+++ b/combine.py
@@ -38,7 +38,7 @@ if args.enrich:
     winnow('crop.json', 'crop.json', 'enrich.json')
 bale('crop.json', out_file, out_type)
 
-if args.tiq-test:
+if args.tiq_test:
     tiq_output('crop.json', 'enrich.json')
 
 if args.delete:


### PR DESCRIPTION
This is a fix for issue #45. Arguments with dashes in them (`tiq-test`) get converted to underscores (`args.tiq_test`). This fix WFM. :grin:
