### PR TITLE
Set dnsdb to None if we don't have an API key

### DIFF
--- a/winnower.py
+++ b/winnower.py
@@ -165,7 +165,7 @@ def winnow(in_file, out_file, enr_file):
             # TODO: validate these (cf. https://github.com/mlsecproject/combine/issues/15 )
             logger.info('Enriching %s' % addr)
             wheat.append(each)
-            if enrich_dns:
+            if enrich_dns and dnsdb:
                 e_data = (addr, addr_type, direction, source, note, date, enrich_FQDN(addr, date, dnsdb))
                 enriched.append(e_data)
         else:


### PR DESCRIPTION
Otherwise we get a bunch of `HTTP Error 403: forbidden` errors from requesting with an invalid API key.
