### PR TITLE
Remove inactive sources

### DIFF
--- a/outbound_urls.txt
+++ b/outbound_urls.txt
@@ -1,6 +1,7 @@
 http://www.malwaregroup.com/ipaddresses
 http://malc0de.com/bl/IP_Blacklist.txt
 https://zeustracker.abuse.ch/blocklist.php?download=ipblocklist
+https://palevotracker.abuse.ch/blocklists.php?download=ipblocklist
 http://reputation.alienvault.com/reputation.data
 http://www.nothink.org/blacklist/blacklist_malware_dns.txt
 http://www.nothink.org/blacklist/blacklist_malware_http.txt

--- a/outbound_urls.txt
+++ b/outbound_urls.txt
@@ -1,8 +1,6 @@
 http://www.malwaregroup.com/ipaddresses
 http://malc0de.com/bl/IP_Blacklist.txt
 https://zeustracker.abuse.ch/blocklist.php?download=ipblocklist
-https://spyeyetracker.abuse.ch/blocklist.php?download=ipblocklist
-https://palevotracker.abuse.ch/blocklists.php?download=ipblocklist
 http://reputation.alienvault.com/reputation.data
 http://www.nothink.org/blacklist/blacklist_malware_dns.txt
 http://www.nothink.org/blacklist/blacklist_malware_http.txt


### PR DESCRIPTION
PalevoTracker now yields a 404 and SpyeyeTracker is explicitly disabled.