### PR TITLE
Update to gevent 1.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ CsvSchema==1.1.1
 argparse>=1.2.1,<1.4.0
 beautifulsoup4==4.3.2
 feedparser==5.1.3
-gevent==1.0.1
+gevent==1.0.2
 greenlet>=0.4.2,<0.5.0
 -e git+https://github.com/rtdean/grequests@19239a34b00b8ac226b21f01b0fb55e869097fb7#egg=grequests-origin
 netaddr==0.7.12


### PR DESCRIPTION
Using gevent 1.0.1 results in issues when accessing https sources with python 2.7.9:
2015-10-12 20:22:54,826 - combine.reaper - INFO - Fetching inbound URLs
2015-10-12 20:23:00,659 - combine.reaper - ERROR - Request <grequests.AsyncRequest object at 0x3c960746bd0> failed: TypeError("**init**() got an unexpected keyword argument 'server_hostname'",)
2015-10-12 20:23:00,659 - combine.reaper - ERROR - Request <grequests.AsyncRequest object at 0x3c960756490> failed: TypeError("**init**() got an unexpected keyword argument 'server_hostname'",)
2015-10-12 20:23:00,676 - combine.reaper - INFO - Fetching outbound URLs
2015-10-12 20:23:12,284 - combine.reaper - ERROR - Request <grequests.AsyncRequest object at 0x3c960772810> failed: TypeError("**init**() got an unexpected keyword argument 'server_hostname'",)
2015-10-12 20:23:12,284 - combine.reaper - ERROR - Request <grequests.AsyncRequest object at 0x3c95fe63790> failed: TypeError("**init**() got an unexpected keyword argument 'server_hostname'",)
2015-10-12 20:23:12,284 - combine.reaper - ERROR - Request <grequests.AsyncRequest object at 0x3c95fe4add0> failed: TypeError("**init**() got an unexpected keyword argument 'server_hostname'",)
2015-10-12 20:23:12,300 - combine.reaper - INFO - Storing raw feeds in harvest.json

See https://github.com/gevent/gevent/issues/477 for details.
