### PR TITLE
Remove the VIRBL input source as this is no longer active.

### DIFF
--- a/inbound_urls.txt
+++ b/inbound_urls.txt
@@ -24,5 +24,4 @@ http://www.nothink.org/blacklist/blacklist_ssh_day.txt
 https://www.packetmail.net/iprep.txt
 http://www.autoshun.org/files/shunlist.csv
 http://charles.the-haleys.org/ssh_dico_attack_hdeny_format.php/hostsdeny.txt
-http://virbl.org/download/virbl.dnsbl.bit.nl.txt
 http://botscout.com/last_caught_cache.htm


### PR DESCRIPTION
The VIRBL link no longer works, and the website suggests that all references to the data source should now be removed.